### PR TITLE
added in support for assets stored with Amazon S3

### DIFF
--- a/services/ZipAssetsService.php
+++ b/services/ZipAssetsService.php
@@ -12,7 +12,7 @@ class ZipAssetsService extends BaseApplicationComponent
         $criteria->id = $files;
         $criteria->limit = null;
         $assets = $criteria->find();
-        
+
         // Set destination zip
         $destZip = craft()->path->getTempPath() . $filename . '_' . time() . '.zip';
         
@@ -22,23 +22,40 @@ class ZipAssetsService extends BaseApplicationComponent
         // Loop through assets
         foreach($assets as $asset) {
         
-            // Get asset source
             $source = $asset->getSource();
-
-            // Get asset folder
-            $folder = $asset->getFolder();
-            
-            // Get asset path
-            $path = craft()->config->parseEnvironmentString($source->settings['path']) . $folder['path'];
-            
-            // Add to zip
-            Zip::add($destZip, $path.$asset->filename, $path);
-        
+            switch ($source->type) {
+                case 'Local':
+                    // Get asset folder
+                    $folder = $asset->getFolder();
+                    // Get asset path
+                    $path = craft()->config->parseEnvironmentString($source->settings['path']) . $folder['path'];
+                    
+                    // Add to zip
+                    Zip::add($destZip, $path.$asset->filename, $path);
+                    break;
+                case 'S3':
+                    try{
+                        $ch = curl_init();
+                        curl_setopt($ch, CURLOPT_URL, $asset->getUrl());
+                        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+                        $newImageData = curl_exec($ch);
+                        curl_close($ch);
+                        $tempPath = craft()->path->getTempPath();
+                        IOHelper::writeToFile($tempPath.$asset->filename, $newImageData);
+                        // Add to zip
+                        Zip::add($destZip, $tempPath.$asset->filename, $tempPath);
+                        // Remove file from temp folder
+                        IOHelper::deleteFile($tempPath.$asset->filename, true);
+                    } 
+					catch (Exception $e) {
+                        Craft::log("Failed to get asset ID ".$asset->id." from url ".$asset->getUrl().". Caught exception: ".$e->getMessage(), LogLevel::Error);
+                    }
+                    break;
+                default:
+                    Craft::log("Tried to add asset ID ".$asset->id." to a zip for downloading but file type ".$asset->getSource()->type." is not supported", LogLevel::Error);
+                }
         }
-            
         // Return zip destination
         return $destZip;
-    
     }
-    
 }


### PR DESCRIPTION
Hello from the UK!

First off thanks for the plugin it has been very useful!

I've forked it to add in support for assets stored with Amazon S3!

In short what I've done is...

1) Check the asset type (local/S3)
2) If S3 do the following...
           a) Transfer file from S3 and store in Craft temp folder
           b) Add file to zip
           c) Remove file from temp

What do you think? Because the files need to first be transferred from S3 to the temp folder there is a gap between the user clicking download and the start of the zip download! Other than that the plugin has worked fine with the testing I've done.

Thanks,

Sam