### PR TITLE
Safeguard against filenames with slashes

### DIFF
--- a/services/ZipAssetsService.php
+++ b/services/ZipAssetsService.php
@@ -30,6 +30,9 @@ class ZipAssetsService extends BaseApplicationComponent
         $criteria->limit = null;
         $assets = $criteria->find();
 
+        // Replace slashes with dashes
+        $filename = str_replace('/', '-', $filename);
+
         // Set destination zip
         $destZip = craft()->path->getTempPath().$filename.'_'.time().'.zip';
 


### PR DESCRIPTION
If the `$filename` has a slash in it, a corrupt zip file will be generated. To protect against this, we simply replace slashes with dashes.